### PR TITLE
Fix deprecated logging.

### DIFF
--- a/autoremoveplus/core.py
+++ b/autoremoveplus/core.py
@@ -43,7 +43,8 @@
 
 from __future__ import unicode_literals
 
-from deluge.log import LOG as log
+import logging
+log = logging.getLogger(__name__)
 from deluge.plugins.pluginbase import CorePluginBase
 import deluge.component as component
 import deluge.configmanager


### PR DESCRIPTION
This will fix deprecated logging, which will otherwise make the plugin fail working in next major deluge version update. If checking deluge's log.py file, there's a comment there about informing plugin authors about this, whenever seeing such. Also, reason for this PR more specifically, is that without this fix, then doesn't work in the unofficial deluge2 windows installer by petersasi.
